### PR TITLE
Update index.html

### DIFF
--- a/btcath/index.html
+++ b/btcath/index.html
@@ -47,7 +47,7 @@
                  class="d-inline-block align-text-top">
             Bitcoin is Beautiful
         </h1>
-        <a class="nav-link" href="https://github.com/sorukumar/ChartingExperiment/btcath">Github</a>
+        <a class="nav-link" href="https://github.com/sorukumar/ChartingExperiment/tree/main/btcath">Github</a>
     </div>
 </nav>
 


### PR DESCRIPTION
Fix broken hyperlink.

Changing the link...
FROM: https://github.com/sorukumar/ChartingExperiment/btcath TO: https://github.com/sorukumar/ChartingExperiment/tree/main/btcath

As it is now, if someone is viewing the page at https://sorukumar.github.io/ChartingExperiment/btcath, and they click on the link in the upper right corner (see https://archive.ph/TS6Od#selection-33.0-33.6), that link is broken.  

See https://archive.ph/oTZxL for proof that the link is now a 404 error.

Awesome page, btw.  I love it!  I found it at https://stacker.news/items/445362/r/1GLENCoop